### PR TITLE
Fix multiples of three and five logic

### DIFF
--- a/src/main/java/com/codurance/fizzbuzz/FizzBuzz.java
+++ b/src/main/java/com/codurance/fizzbuzz/FizzBuzz.java
@@ -5,9 +5,9 @@ class FizzBuzz {
     private static final String FIZZ = "Fizz";
 
     String convert(int i) {
+        if (divisibleBy(15, i)) return FIZZ + BUZZ;
         if (divisibleBy(3, i)) return FIZZ;
         if (divisibleBy(5, i)) return BUZZ;
-        if (divisibleBy(15, i)) return FIZZ + BUZZ;
 
         return String.valueOf(i);
     }


### PR DESCRIPTION
Unit tests were failing due to the location of the multiple "divisibleB(15, i )" method.